### PR TITLE
feat: add navigation to experience pages

### DIFF
--- a/src/routes/about-me/Timeline.svelte
+++ b/src/routes/about-me/Timeline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { preloadData, pushState, goto } from '$app/navigation';
+	import { goto } from '$app/navigation';
 
 	interface TimelineEntry {
 		id: string;

--- a/src/routes/experience/[slug]/+page.server.ts
+++ b/src/routes/experience/[slug]/+page.server.ts
@@ -5,6 +5,8 @@ interface ResultData {
 	title: string;
 	content: string;
 	slug: string;
+	next?: string;
+	previous?: string;
 }
 
 export async function load({ params }: { params: { slug: string } }): Promise<ResultData> {
@@ -15,6 +17,8 @@ export async function load({ params }: { params: { slug: string } }): Promise<Re
 	return {
 		title: experiences[slug].title,
 		content: experiences[slug].content,
-		slug
+		slug,
+		next: experiences[slug].next,
+		previous: experiences[slug].previous
 	};
 }

--- a/src/routes/experience/[slug]/+page.svelte
+++ b/src/routes/experience/[slug]/+page.svelte
@@ -1,16 +1,52 @@
 <script lang="ts">
+	import { ChevronBack, ChevronForward } from 'svelte-ionicons'
 	import { marked } from 'marked';
+	import { goto } from '$app/navigation';
 
 	export let data;
 
-	$: ({ content = '', title } = data);
+	$: ({ content = '', title, next, previous } = data);
+
+	const handleClick = (slug: string | undefined) => {
+		if (!slug) return;
+
+		goto(slug);
+	};
+
 </script>
 
 <div class="markdown-wrapper">
 	<h1>{title}</h1>
 	{@html marked(content)}
+	<div class="navigation-links pico">
+		<button on:click={() => handleClick(previous)} disabled={!Boolean(previous)} class="goto outline contrast" role="link">
+			<ChevronBack />
+		</button>
+		<button on:click={() => handleClick(next)} disabled={!Boolean(next)} class="goto next outline contrast" role="link">
+			<ChevronForward />
+		</button>
+	</div>
 </div>
 
 <style>
 	@import '$lib/assets/css/md-styles.css';
+
+	.navigation-links {
+		padding-top: 3.2rem;
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		gap: 1.6rem;
+		justify-content: space-between;
+	}
+
+	.goto {
+		display: grid;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.next {
+		grid-column: -1;
+	}
+
 </style>

--- a/src/routes/experience/[slug]/data.server.ts
+++ b/src/routes/experience/[slug]/data.server.ts
@@ -9,6 +9,8 @@ export interface ExperienceData {
 	[slug: string]: {
 		title: string;
 		content: string;
+		next?: string;
+		previous?: string;
 	};
 }
 
@@ -60,18 +62,28 @@ const experiences: ExperienceData = {
 	}
 };
 
+const LINK_PREFIX = '/experience/';
+
 export const getExperiences = async (slug: string): Promise<ExperienceData> => {
-	if (!experiences[slug]) {
+	const keys = Object.keys(experiences);
+	const index = keys.indexOf(slug);
+
+	if (index === -1) {
 		throw error(404, 'Page not found');
 	}
+
+	const previous = index > 0 ? `${LINK_PREFIX}${keys[index - 1]}` : null;
+	const next = index < keys.length - 1 ? `${LINK_PREFIX}${keys[index + 1]}` : null;
 
 	return {
 		[slug]: {
 			title: experiences[slug].title,
-			content: await parseMd(experiences[slug].content)
+			content: await parseMd(experiences[slug].content),
+			next: next ? next : undefined,
+			previous: previous ? previous : undefined,
 		}
 	};
-};
+}
 
 const parseMd = async (filepath: string): Promise<string> => {
 	const resolvedFpath = resolve(join(dirname(fileURLToPath(import.meta.url)), filepath));


### PR DESCRIPTION
```
Add `next` and `previous` fields to the experience data interface to 
facilitate navigation between experiences. Implement navigation 
buttons with respective handlers using Svelte's `goto` function to 
switch between pages. Enhance layout with new styles for navigation 
links and buttons. Clean up unused imports in `Timeline.svelte` for 
efficiency.
```