### PR TITLE
Fix semantic-release workflow token fallback

### DIFF
--- a/.github/workflows/test-containerize-deploy.yml
+++ b/.github/workflows/test-containerize-deploy.yml
@@ -49,7 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          fetch-depth: 0
+          token: ${{ secrets.SEMANTIC_RELEASE_PAT || github.token }}
           persist-credentials: true
       - name: Semantic Release
         id: semantic
@@ -63,7 +64,7 @@ jobs:
             @semantic-release/npm
             @semantic-release/git
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT || github.token }}
 
   build:
     name: 'Build and Push Docker Image'

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         with:
@@ -56,4 +58,4 @@ jobs:
             @semantic-release/npm
             @semantic-release/git
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT || github.token }}


### PR DESCRIPTION
## Summary
- update semantic-release checkouts to fetch full git history
- allow semantic-release to fall back to the default GitHub token when SEMANTIC_RELEASE_PAT is unavailable

## Validation
- git diff --check
- pre-commit formatting hook during commit