### PR TITLE
Fix embedding index sync for existing posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # [1.19.0](https://github.com/codigo/website/compare/v1.18.3...v1.19.0) (2026-04-21)
 
-
 ### Bug Fixes
 
-* correct Go syntax highlighting import in journal page ([#103](https://github.com/codigo/website/issues/103)) ([150b219](https://github.com/codigo/website/commit/150b219b680195c647ec27f5c8ff346f46150f98))
-
+- correct Go syntax highlighting import in journal page ([#103](https://github.com/codigo/website/issues/103)) ([150b219](https://github.com/codigo/website/commit/150b219b680195c647ec27f5c8ff346f46150f98))
 
 ### Features
 
-* add Go syntax highlighting to journal page ([4d3e1ab](https://github.com/codigo/website/commit/4d3e1ab9c4e67cb632d2de199cac31ac3ae522a5))
+- add Go syntax highlighting to journal page ([4d3e1ab](https://github.com/codigo/website/commit/4d3e1ab9c4e67cb632d2de199cac31ac3ae522a5))
 
 ## [1.18.3](https://github.com/codigo/website/compare/v1.18.2...v1.18.3) (2026-04-06)
 

--- a/src/routes/api/journal/generate-embeddings/+server.ts
+++ b/src/routes/api/journal/generate-embeddings/+server.ts
@@ -4,7 +4,7 @@ import { generateAISummary, generatePostEmbedding } from '$lib/services/embeddin
 import pb, { PocketBaseSingleton } from '$lib/services/pb';
 import type { Post } from '$lib/types';
 import { SECRET_OPENAI_API_KEY } from '$env/static/private';
-import { addToIndex } from '$lib/services/vectorIndex';
+import { addToIndex, rebuildIndex } from '$lib/services/vectorIndex';
 
 /**
  * POST endpoint to generate AI summaries and embeddings for posts.
@@ -52,9 +52,21 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 			// Check if we should process this post
 			if (!regenerate && post.embedding && post.ai_summary) {
+				if (post.publish) {
+					addToIndex(post.id, post.embedding, {
+						id: post.id,
+						slug: post.slug,
+						title: post.title,
+						summary: post.summary,
+						tags: post.tags,
+						created: post.created,
+						photo_metadata: post.photo_metadata
+					});
+				}
+
 				return json({
 					success: true,
-					message: 'Post already has embeddings',
+					message: 'Post already has embeddings and was synced to the search index',
 					processed: 0,
 					total: 1
 				});
@@ -89,9 +101,11 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		log.info({ postsToProcess: postsToProcess.length }, 'Posts to process');
 
 		if (postsToProcess.length === 0) {
+			await rebuildIndex();
+
 			return json({
 				success: true,
-				message: 'No posts need embedding generation',
+				message: 'No posts need embedding generation; search index rebuilt',
 				processed: 0,
 				total: totalPosts
 			});

--- a/src/routes/api/journal/generate-embeddings/server.generate-embeddings.test.ts
+++ b/src/routes/api/journal/generate-embeddings/server.generate-embeddings.test.ts
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
 	ensureAdminAuth: vi.fn(),
 	generateAISummary: vi.fn(),
 	generatePostEmbedding: vi.fn(),
-	addToIndex: vi.fn()
+	addToIndex: vi.fn(),
+	rebuildIndex: vi.fn()
 }));
 
 vi.mock('$env/static/private', () => ({ SECRET_OPENAI_API_KEY: 'test-api-key' }));
@@ -36,7 +37,10 @@ vi.mock('$lib/services/embeddings', () => ({
 	generatePostEmbedding: mocks.generatePostEmbedding
 }));
 
-vi.mock('$lib/services/vectorIndex', () => ({ addToIndex: mocks.addToIndex }));
+vi.mock('$lib/services/vectorIndex', () => ({
+	addToIndex: mocks.addToIndex,
+	rebuildIndex: mocks.rebuildIndex
+}));
 
 import { POST } from './+server';
 
@@ -89,11 +93,13 @@ beforeEach(() => {
 	mocks.generateAISummary.mockReset();
 	mocks.generatePostEmbedding.mockReset();
 	mocks.addToIndex.mockReset();
+	mocks.rebuildIndex.mockReset();
 
 	mocks.update.mockResolvedValue({});
 	mocks.ensureAdminAuth.mockResolvedValue(undefined);
 	mocks.generateAISummary.mockResolvedValue('AI generated summary');
 	mocks.generatePostEmbedding.mockResolvedValue(MOCK_EMBEDDING);
+	mocks.rebuildIndex.mockResolvedValue(undefined);
 });
 
 describe('POST /api/journal/generate-embeddings', () => {
@@ -133,7 +139,7 @@ describe('POST /api/journal/generate-embeddings', () => {
 			expect(mocks.addToIndex).not.toHaveBeenCalled();
 		});
 
-		it('returns early without calling addToIndex when post already has embeddings', async () => {
+		it('syncs a published post to the index when it already has embeddings', async () => {
 			mocks.getOne.mockResolvedValue(
 				makePost({ ai_summary: 'existing', embedding: MOCK_EMBEDDING })
 			);
@@ -145,7 +151,31 @@ describe('POST /api/journal/generate-embeddings', () => {
 
 			const body = await response.json();
 			expect(body.processed).toBe(0);
-			expect(body.message).toBe('Post already has embeddings');
+			expect(body.message).toBe('Post already has embeddings and was synced to the search index');
+			expect(mocks.addToIndex).toHaveBeenCalledOnce();
+			expect(mocks.addToIndex).toHaveBeenCalledWith('post-1', MOCK_EMBEDDING, {
+				id: 'post-1',
+				slug: 'test-post',
+				title: 'Test Post',
+				summary: 'A test post',
+				tags: 'test, vitest',
+				created: '2024-01-01',
+				photo_metadata: {}
+			});
+		});
+
+		it('does not sync an unpublished post that already has embeddings', async () => {
+			mocks.getOne.mockResolvedValue(
+				makePost({ publish: false, ai_summary: 'existing', embedding: MOCK_EMBEDDING })
+			);
+
+			const response = await POST({
+				request: makeRequest({ postId: 'post-1' }),
+				locals: mockLocals
+			} as Parameters<typeof POST>[0]);
+
+			const body = await response.json();
+			expect(body.processed).toBe(0);
 			expect(mocks.addToIndex).not.toHaveBeenCalled();
 		});
 
@@ -201,6 +231,23 @@ describe('POST /api/journal/generate-embeddings', () => {
 				MOCK_EMBEDDING,
 				expect.objectContaining({ id: 'post-1' })
 			);
+		});
+
+		it('rebuilds the index when no posts need embedding generation', async () => {
+			mocks.getFullList.mockResolvedValue([
+				makePost({ id: 'post-1', ai_summary: 'existing', embedding: MOCK_EMBEDDING })
+			]);
+
+			const response = await POST({
+				request: makeRequest({}),
+				locals: mockLocals
+			} as Parameters<typeof POST>[0]);
+
+			const body = await response.json();
+			expect(body.processed).toBe(0);
+			expect(body.message).toBe('No posts need embedding generation; search index rebuilt');
+			expect(mocks.rebuildIndex).toHaveBeenCalledOnce();
+			expect(mocks.addToIndex).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
## Summary
- sync already-embedded single posts into the in-memory HNSW search index
- rebuild the search index when batch embedding generation has no work to do
- update tests for stale-index repair paths
- format current changelog entry so lint passes

## Validation
- npm run test:unit -- src/routes/api/journal/generate-embeddings/server.generate-embeddings.test.ts
- npm run check
- npm run lint
- verified deployed search returns the latest distributed task queue post at rank 1