### PR TITLE
fix: prevent header overlapping page content

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -197,7 +197,7 @@
 
 		.main-nav {
 			justify-content: flex-end;
-			padding-bottom: 0.8rem;
+			padding: 0.8rem 0;
 		}
 
 		.hamburger-menu {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -109,7 +109,11 @@
 	.main {
 		max-width: var(--max-width);
 		margin: 0 auto;
-		padding-top: 4rem;
+		padding-top: var(--header-offset, 12rem);
+	}
+
+	:root {
+		--header-offset: 12rem;
 	}
 
 	@media (max-width: 1200px) {
@@ -135,6 +139,7 @@
 	@media (max-width: 600px) {
 		:root {
 			--max-width: 50rem;
+			--header-offset: 6.4rem;
 		}
 	}
 	@media (max-width: 500px) {

--- a/tests/responsive.test.ts
+++ b/tests/responsive.test.ts
@@ -39,6 +39,16 @@ test.describe('Responsive Design', () => {
 			// Form should not exceed viewport width
 			expect(box!.width).toBeLessThanOrEqual(375);
 		});
+
+		test('contact title starts below fixed header on mobile', async ({ page }) => {
+			await page.goto('/contact');
+			const headerBox = await page.locator('.header').boundingBox();
+			const titleBox = await page.locator('.contact-title').boundingBox();
+
+			expect(headerBox).not.toBeNull();
+			expect(titleBox).not.toBeNull();
+			expect(titleBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height);
+		});
 	});
 
 	test.describe('Desktop viewport (1280x720)', () => {
@@ -57,6 +67,16 @@ test.describe('Responsive Design', () => {
 			const style = await skillsList.evaluate((el) => getComputedStyle(el).gridTemplateColumns);
 			const columns = style.split(' ').filter((v) => v !== '');
 			expect(columns.length).toBe(2);
+		});
+
+		test('journal search starts below fixed header on desktop', async ({ page }) => {
+			await page.goto('/journal/page/1');
+			const headerBox = await page.locator('.header').boundingBox();
+			const searchBox = await page.locator('.search-wrapper').boundingBox();
+
+			expect(headerBox).not.toBeNull();
+			expect(searchBox).not.toBeNull();
+			expect(searchBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- reserve a shared top offset for the fixed header
- tighten mobile header padding and mobile content offset
- add responsive regression tests for contact and journal first content

## Verification
- npm run check
- npm run lint
- npx playwright test tests/responsive.test.ts