### PR TITLE
fix(ci): migrate GitHub Actions to Node 24 and release style commits

### DIFF
--- a/.github/workflows/test-containerize-deploy.yml
+++ b/.github/workflows/test-containerize-deploy.yml
@@ -22,8 +22,8 @@ jobs:
         SECRET_POCKETBASE_ADMIN_EMAIL: ${{ secrets.SECRET_POCKETBASE_ADMIN_EMAIL }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       - name: Install dependencies
@@ -47,14 +47,14 @@ jobs:
     name: 'Semantic Release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.SEMANTIC_RELEASE_PAT || github.token }}
           persist-credentials: true
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           semantic_version: 24.1.2
           extra_plugins: |
@@ -72,7 +72,7 @@ jobs:
     needs: semantic-release
     if: needs.semantic-release.outputs.new_release_published == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set version from semantic release output
         run: |
           echo "TAG=${{ needs.semantic-release.outputs.new_release_version }}" >> $GITHUB_ENV
@@ -107,7 +107,7 @@ jobs:
     needs: [semantic-release, build]
     if: needs.semantic-release.outputs.new_release_published == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Login to Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -21,8 +21,8 @@ jobs:
         SECRET_POCKETBASE_ADMIN_PASSWORD: ${{ secrets.SECRET_POCKETBASE_ADMIN_PASSWORD }}
         SECRET_POCKETBASE_ADMIN_EMAIL: ${{ secrets.SECRET_POCKETBASE_ADMIN_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       - name: Install dependencies
@@ -43,11 +43,11 @@ jobs:
     name: 'Semantic Release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           dry_run: true
           semantic_version: 24.1.2

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+# Git worktrees
+.worktrees/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,7 @@ export default [
 		}
 	},
 	{
-		ignores: ['build/', '.svelte-kit/', 'dist/', 'pb_data/', 'pb/']
+		ignores: ['build/', '.svelte-kit/', 'dist/', 'pb_data/', 'pb/', '.worktrees/']
 	},
 	{
 		files: ['**/*.svelte'],

--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
 						{
 							"type": "content",
 							"release": "patch"
+						},
+						{
+							"type": "style",
+							"release": "patch"
 						}
 					]
 				}


### PR DESCRIPTION
## Summary
- Skipped build/deploy jobs were caused by semantic-release ignoring `style:` commits, not Node.js deprecation warnings.
- Upgrade `actions/checkout` to v5, `actions/setup-node` to v5, and `cycjimmy/semantic-release-action` to v6 for native Node 24 support.
- Treat `style` commits as patch releases so visual changes trigger deploy.
- Ignore `.worktrees/` in Prettier/ESLint so local worktrees do not break pre-commit.

## Test plan
- [ ] PR workflow passes without Node 20 deprecation warnings
- [ ] After merge, main workflow publishes a release and runs build/deploy for pending style changes


Made with [Cursor](https://cursor.com)